### PR TITLE
Update feature-reference.md

### DIFF
--- a/docs/user_guide/feature-reference.md
+++ b/docs/user_guide/feature-reference.md
@@ -46,29 +46,29 @@ Backups in Athens are stored in a `.bkp` format which is easy to restore from. T
 
 Restoring from a `.bkp` file is a five-step process.
 
-Locate your database folder
+1. Locate your database folder
 
-Backups in Athens are stored in your main DB folder and have a `.bkp` file extension. To locate your database folder, in the Athens app, click the database icon on the toolbar and you will see the current location of your database. In this folder, you will see your backup files.
+Backups in Athens are stored in your main DB folder and have a `.bkp` file extension. To locate your database folder, in the Athens app, click the database icon on the toolbar and you will see the current location of your database. In this folder, you will see your backup files. Remember the location of this folder and close Athens.
 
 ![](/img/gitbook/image-4.png)
 
-Relocate your `index.transit` file
+2. Relocate your `index.transit` file
 
 Before we proceed to the next step, locate your current `index.transit` file and relocate it to another folder.
 
 ![](/img/gitbook/123552515-160cc780-d794-11eb-961d-8c277b3f632e-1.gif)
 
-Locate the backup file you want to restore from
+3. Locate the backup file you want to restore from
 
 Once you are in the folder, find a file with a creation time that corresponds to the state of your database you would like to revert to. For instance, let's say you want to restore my DB to where it was on the night of June 6th. In this case, you find a `.bkp` file with a creation time around that specific time. You can also use a [Unix time converter](https://time.is/Unix_time_converter) to figure out when Athens created a `.bkp` file.
 
-Rename the backup file
+4. Rename the backup file
 
 At this point, rename the selected `.bkp` file to `index.transit`.
 
 ![](/img/gitbook/123552503-0ab99c00-d794-11eb-938a-14fe80200184.gif)
 
-Open the new file in Athens
+5. Open the new file in Athens
 
 ![](/img/gitbook/image-5.png)
 
@@ -76,7 +76,7 @@ Reopen Athens, click the database icon once again and make sure you are on the *
 
 Frequency of backups
 
-You can set your desired backup and auto save frequency in the settings page. By default, Athens saves a copy of your database every 15 seconds into your main folder.
+You can set your desired backup and auto save frequency in the settings page. By default, Athens saves a copy of your database 15 seconds after you make a change into your main folder.
 
 Best practices
 
@@ -86,7 +86,7 @@ Additionally, because the backups are locally stored \(for the moment\), it make
 
 ## Import
 
-To download a `.edn` file from Roam Research, visit your Roam graph and click on the three doc symbol **⋯** in the top bar, then **Export All**. Choose **EDN** from the Export Format dropdown, then click **Export All**.
+To create a `.edn` file from Roam Research, visit your Roam graph and click on the three doc symbol **⋯** in the top bar, then **Export All**. Choose **EDN** from the Export Format dropdown, then click **Export All**.
 
 You'll download a `.zip` file, which you need to open/extract the `.edn` file out of.
 


### PR DESCRIPTION
Make the 5 steps of back-up procedure visually stand out.
Instruct to close Athens in step 1 (since it is reopened in step 5).

Changed the note about update frequency (IS THIS CORRECT?)

Make clearer that before importing in Athens, one has to export in Roam.